### PR TITLE
Bump spring_version in /src/itstack-demo-rpc/itstack-demo-rpc

### DIFF
--- a/src/itstack-demo-rpc/itstack-demo-rpc/pom.xml
+++ b/src/itstack-demo-rpc/itstack-demo-rpc/pom.xml
@@ -25,7 +25,7 @@
 
     <properties>
         <!-- Common libs -->
-        <spring_version>3.2.0.RELEASE</spring_version>
+        <spring_version>5.2.5.RELEASE</spring_version>
         <javassist_version>3.19.0-GA</javassist_version>
         <netty_version>4.1.36.Final</netty_version>
         <!-- 3rd extends libs -->


### PR DESCRIPTION
Bumps `spring_version` from 3.2.0.RELEASE to 5.2.5.RELEASE.

Updates `spring-core` from 3.2.0.RELEASE to 5.2.5.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v3.2.0.RELEASE...v5.2.5.RELEASE)

Updates `spring-beans` from 3.2.0.RELEASE to 5.2.5.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v3.2.0.RELEASE...v5.2.5.RELEASE)

Updates `spring-context` from 3.2.0.RELEASE to 5.2.5.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v3.2.0.RELEASE...v5.2.5.RELEASE)

Updates `spring-test` from 3.2.0.RELEASE to 5.2.5.RELEASE
- [Release notes](https://github.com/spring-projects/spring-framework/releases)
- [Commits](https://github.com/spring-projects/spring-framework/compare/v3.2.0.RELEASE...v5.2.5.RELEASE)

Signed-off-by: dependabot[bot] <support@github.com>